### PR TITLE
Fix issue that occurs on GCC

### DIFF
--- a/wrappers/fxlib/fxhook.c
+++ b/wrappers/fxlib/fxhook.c
@@ -259,7 +259,7 @@ void HookTimeGetTime(const uint32_t caddr)
         TICK_HOOK(modList.modName[i]);
     }
 #undef TICK_HOOK
-compat_patched:
+compat_patched: ;
     PCOMPATFX nptr = fxCompatTblPtr();
     for (int i = 0; nptr && nptr[i].modName; i++) {
         if (nptr[i].op_mask & HP_DONE)


### PR DESCRIPTION
Compiling on Ubuntu WSL2 with GCC, I got "error: a label can only be part of a statement and a declaration is not a statement. "

Fixed by adding a ";" to line 262.