### PR TITLE
Initialize the pad variable

### DIFF
--- a/wrappers/3dfx/dxe/glidedxe.c
+++ b/wrappers/3dfx/dxe/glidedxe.c
@@ -961,7 +961,7 @@ void PT_CALL guTexDownloadMipMap(uint32_t arg0, uint32_t arg1, uint32_t arg2) {
 }
 void PT_CALL guTexDownloadMipMapLevel(uint32_t arg0, uint32_t arg1, uint32_t arg2) {
     void **src = (void **)arg2;
-    uint8_t pad[ALIGNED(1)];
+    uint8_t pad[ALIGNED(1)] = {0};
     uint32_t texBytes  = guTexSize(arg0, arg1);
     if (texBytes) {
         fifoAddData(0, (uint32_t)(*src), texBytes);


### PR DESCRIPTION
On never versions of gcc this results in a warning which, due to -Werror, causes the build of the wrapper to fail.