### PR TITLE
Make building the OVL a little easier on Linux

### DIFF
--- a/scripts/conf_wrapper
+++ b/scripts/conf_wrapper
@@ -73,16 +73,24 @@ if [ ! -f ../src/Makefile.in ]; then
     exit 1
 fi
 cat ../src/Makefile.in | sed "s/^\(CROSS=\).*/\1$CROSS/" > $MKFILE
+INCLUDES_OVL='-I..\\..\\..\\qemu-0\\hw\\3dfx -I..\\src'
 if [ $CC_CHECK -eq 2 ]; then
+    INCLUDES_OVL='-I../../../qemu-0/hw/3dfx -I../src'
     sed -i -e "s/^\(RC=\)/\1\$(CROSS)/" $MKFILE
     sed -i -e "s/^\(STRIP=\)/\1\$(CROSS)/" $MKFILE
     sed -i -e "s/^\(DLLTOOL=\)/\1\$(CROSS)/" $MKFILE
     sed -i -e "s/^\(TOOLS=\)wglinfo.exe.*/\1/" $MKFILE
     sed -i -e "/.*MSYSTEM\"\ !=\ \"MINGW32\".*/d" $MKFILE
 fi
+
+sed -i -e "s#^\(INCLUDES_OVL=\)#\1${INCLUDES_OVL}#" $MKFILE
+
 if [ -z $(which wcc386 2>/dev/null) ]; then
     echo -- DOS32 OVL not supported --
     sed -i -e "/.*make\ \-C\ .*ovl/d" $MKFILE
+else
+    WATCOM_PATH="$(dirname $(which wcc386))"
+    sed -i -e "s#^\(WATCOM_PATH=\)#\1${WATCOM_PATH}#" $MKFILE
 fi
 if [ -z $(which i686-pc-msdosdjgpp-gcc 2>/dev/null) ]; then
     echo -- DJGPP DXE not supported --

--- a/wrappers/3dfx/ovl/Makefile
+++ b/wrappers/3dfx/ovl/Makefile
@@ -1,8 +1,5 @@
-WATCOM_PATH=/opt/watcom11/bin
 WCC=$(WATCOM_PATH)/wcc386
 WLD=$(WATCOM_PATH)/wlink
-QEMU_SRC_DIR=..\..\..\qemu-0
-INCLUDES=-I$(QEMU_SRC_DIR)\hw\3dfx -I..\src
 CFLAGS=-zq -we -6s -ohtx -bd -fpi87
 OUTDIR?=build
 
@@ -17,7 +14,7 @@ glide2x.ovl: glideovl.obj
 glideovl.obj: glideovl.c
 	@git rev-parse HEAD | sed "s/\(.......\).*/\#define\ __REV__\ \"\1\-\"/" > stamp.h
 	@echo "  WCC $@"
-	@$(WCC) $(INCLUDES) $(CFLAGS) $<
+	@$(WCC) $(INCLUDES) $(CFLAGS) -fo=$@ $<
 	@rm stamp.h
 
 clean:

--- a/wrappers/3dfx/src/Makefile.in
+++ b/wrappers/3dfx/src/Makefile.in
@@ -1,7 +1,9 @@
 QEMU_SRC_DIR=../../../qemu-0
+INCLUDES_OVL=
 FXLIB=../../fxlib
 GIT=$(shell git rev-parse HEAD | sed "s/\(.......\).*/\1\-/")
 CROSS=
+WATCOM_PATH=
 CC=$(CROSS)gcc
 RC=windres
 DLLTOOL=dlltool
@@ -46,7 +48,7 @@ all: fxlib $(TARGET1) $(TARGET2) $(TARGET3) exports-check fxdrv
 
 fxdrv:
 	@make -C ../dxe OUTDIR=$(OUTDIR)
-	@make -C ../ovl OUTDIR=$(OUTDIR)
+	@make -C ../ovl OUTDIR=$(OUTDIR) WATCOM_PATH=$(WATCOM_PATH) INCLUDES=$(INCLUDES_OVL)
 	@make -C ../drv OUTDIR=$(OUTDIR) CROSS=$(CROSS)
 
 exports-check: $(TARGET1) $(TARGET2) $(TARGET3)


### PR DESCRIPTION
These changes should make it a little easier to build the OVLs on Linux by supporting the open watcom 2.0 betas which can be installed on newer Linuxes. Also detect the install location instead of hardcoding it.