### PR TITLE
Add a Docker build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ An old-stable version of GCC was cherry-picked to re-target for DJGPP. There wer
     $ bash ../../../scripts/conf_wrapper
     $ make && make clean
 
+Alternatively it is possible to build the guest wrappers on Linux using a docker/podman container.
+<br>
+
+    $ scripts/build_wrapper_container
+
 ## Installing Guest Wrappers
 **For Win9x/ME:**  
  - Copy `FXMEMMAP.VXD` to `C:\WINDOWS\SYSTEM`  

--- a/scripts/build_wrapper_container
+++ b/scripts/build_wrapper_container
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+podman=podman
+volume_opts=":z"
+container_name=qemu-3dfx-build:latest
+basedir="$(dirname $(realpath "$0"))"
+sourcedir="${basedir}/../"
+
+if ! which podman > /dev/null; then
+  if ! which docker > /dev/null; then
+    echo "Neither podman nor docker found, cannot continue"
+    exit 1
+  else
+    podman=docker
+    volume_opts=""
+  fi
+fi
+
+echo "Using ${podman} to build"
+   
+${podman} build "${basedir}/docker" -t "${container_name}"
+${podman} run --rm -v "${sourcedir}:/root/source${volume_opts}" "${container_name}"
+

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM fedora:40
+
+WORKDIR /root
+
+RUN dnf -y install mingw32-gcc mingw-w64-tools curl git gcc-c++ which bison flex texinfo patch zlib-devel tar bzip2 gzip xz unzip python-devel m4 dos2unix nasm diffutils perl-File-Compare perl-Digest-SHA automake autoconf xxd && \
+    dnf clean all
+
+ENV WATCOM=/opt/openwatcom
+RUN curl -OL https://github.com/open-watcom/open-watcom-v2/releases/download/2024-05-02-Build/open-watcom-2_0-c-linux-x64 && \
+    chmod +x open-watcom-2_0-c-linux-x64 && \
+    TERM=linux script -qefc "./open-watcom-2_0-c-linux-x64 -is" /dev/null  && \
+    rm open-watcom-2_0-c-linux-x64
+RUN git clone https://github.com/jwt27/build-gcc.git && \
+    cd build-gcc && \
+    git checkout e7135d2 && \
+    sed -i '/build-gdb.sh/d' build-djgpp.sh && \
+    ./build-djgpp.sh --target=i686-pc-msdosdjgpp --prefix=/usr/local --batch all  && \
+    cd .. && \
+    rm -rf build-gcc
+COPY container_build_wrapper /root/container_build_wrapper
+CMD /root/container_build_wrapper

--- a/scripts/docker/container_build_wrapper
+++ b/scripts/docker/container_build_wrapper
@@ -1,0 +1,18 @@
+#!/bin/bash
+cd /root/source
+export PATH=/usr/i686-w64-mingw32/bin/:/usr/local/i686-pc-msdosdjgpp/bin/:/opt/openwatcom/binl64:$PATH
+
+rm -rf wrappers/3dfx/build
+mkdir -p wrappers/3dfx/build
+pushd wrappers/3dfx/build
+bash ../../../scripts/conf_wrapper
+make && make clean
+popd
+
+rm -rf wrappers/mesa/build
+mkdir -p wrappers/mesa/build
+pushd wrappers/mesa/build
+bash ../../../scripts/conf_wrapper
+make && make clean
+popd
+


### PR DESCRIPTION
This should make it a lot easier to build the guest wrappers on Linux. We build all of the prerequisites and finally build the actual wrappers.

Note that this requires #127 and #128 to be applied! :)